### PR TITLE
build CKEditor5

### DIFF
--- a/flask_ckeditor/fields.py
+++ b/flask_ckeditor/fields.py
@@ -8,15 +8,21 @@
     :copyright: (c) 2020 by Grey Li.
     :license: MIT, see LICENSE for more details.
 """
+from flask import Markup, escape
 from wtforms import TextAreaField
-from wtforms.widgets import TextArea
+from wtforms.widgets import html_params
 
-
-class CKEditor(TextArea):
+class CKEditor():
     def __call__(self, field, **kwargs):
-        c = kwargs.pop('class', '') or kwargs.pop('class_', '')
-        kwargs['class'] = u'%s %s' % ('ckeditor', c)
-        return super(CKEditor, self).__call__(field, **kwargs)
+        ckeditor=field.name+'_'
+        kwargs.setdefault('id', field.id)
+        if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
+            kwargs['required'] = True
+        return Markup('<textarea hidden class="ckeditor" %s></textarea><div %s></div><div %s>%s</div>'
+                % (html_params(name=field.name, **kwargs),
+                    html_params(id='ckeditor-toolbox'),
+                    html_params(name=ckeditor, id=ckeditor),
+                    escape(field._value())))
 
 
 class CKEditorField(TextAreaField):


### PR DESCRIPTION
Hello, I build CKEditor5 in this RP.

The user can use ckeditor4 or ckeditor5 by choosing different CKEditor class
`app = CKEditor4(app)  #for ckeditor4`
`app = CKEditor5(app)  #for ckeditor5`

and change the editor_type (support CKEditor5 only) by setting config
`CKEDITOR_EDITOR_TYPE = 'classic'  #and all of the following

- classic for Classic Editor
- inline for Inline Editor
- balloon for Balloon Editor
- balloon-block for Balloon Block Editor
- decoupled-document for Decoupled Editor

hope you will like it!